### PR TITLE
Feature: skimmer improvement

### DIFF
--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.1.0
+          tags: metalwhaledev/newswaters-skimmer:0.1.1

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1584,7 +1584,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What
### `skimmer`
- Change version to `0.1.1`
- Handle skipping based on response content type

## Release procedure
- Run the query:
  ```sql
  DELETE FROM item_urls WHERE status_code = 1 AND status_note = 'Skipping pdf files';
  ```
  (We don't really need `status_note = 'Skipping pdf files'` condition, just to be sure)
- Update to the latest "skimmer" version `0.1.1` from this PR