### PR TITLE
Feature: echolocator model

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,7 +6,6 @@ services:
       dockerfile: Dockerfile.local
     environment:
       - ECHOLOCATOR_PORT=3000
-      - ECHOLOCATOR_MODEL_URL=https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf # OCEAN: Choose a balanced model
     volumes:
       - ./:/usr/src/newswaters/
       - ./models/:/usr/src/models/

--- a/echolocator/Dockerfile.deployment
+++ b/echolocator/Dockerfile.deployment
@@ -1,12 +1,8 @@
+# Previous
+FROM metalwhaledev/newswaters-echolocator:0.2.0 AS previous
+
 # Build
 FROM rust:1.72.0 AS build
-
-RUN cd /usr/src/ && \
-    git clone https://github.com/ggerganov/llama.cpp && \
-    cd llama.cpp/ && \
-    git checkout b1407 && \
-    # OCEAN: Enable AVX support. See: https://github.com/ggerganov/llama.cpp/blob/b1407/CMakeLists.txt
-    LLAMA_NATIVE=OFF make -j
 
 COPY . /usr/src/echolocator/
 
@@ -22,5 +18,5 @@ RUN apt update -y && \
 
 RUN mkdir -p /usr/src/models/
 
-COPY --from=build /usr/src/llama.cpp/main /bin/llama
+COPY --from=previous /bin/llama /bin/llama
 COPY --from=build /usr/src/echolocator/target/release/echolocator /bin/echolocator


### PR DESCRIPTION
## What
### `echolocator`
- Use `llama` bin from previous build.

## Why
We are getting this error when running the latest build:
```
root@echolocator-775c64b7d5-d7nzf:/# llama --model /usr/src/models/mistral-7b-instruct-v0.1.Q5_K_M.gguf --ctx-size 8192 --temp 0.0 --prompt "hello"
Log start
main: build = 1407 (465219b)
main: built with cc (Debian 12.2.0-14) 12.2.0 for x86_64-linux-gnu
main: seed  = 1698575833
Illegal instruction (core dumped)
```
This error occurred before and was fixed by specifying [`LLAMA_NATIVE=OFF` flag](https://github.com/metalwhale/newswaters/blob/echolocator-v0.2.0/echolocator/Dockerfile.deployment#L9) when building the bin file, but somehow it appears again while there is no change made in the setup.
We are temporarily fixing this issue by copying the bin file from the previous build, but we need to investigate further later.