### PR TITLE
Feature: skimmer instruct timeout

### DIFF
--- a/.github/workflows/echolocator.yml
+++ b/.github/workflows/echolocator.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:echolocator"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-echolocator:0.2.3
+          tags: metalwhaledev/newswaters-echolocator:0.2.4

--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.2.1
+          tags: metalwhaledev/newswaters-skimmer:0.2.2

--- a/echolocator/Cargo.lock
+++ b/echolocator/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "echolocator"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -819,6 +819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +934,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",

--- a/echolocator/Cargo.toml
+++ b/echolocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echolocator"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,4 +11,8 @@ axum = "0.6.20"
 futures-util = "0.3.28"
 reqwest = { version = "0.11.22", features = ["stream"] }
 serde = { version = "1.0.189", features = ["derive"] }
-tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.33.0", features = [
+    "macros",
+    "rt-multi-thread",
+    "process",
+] }

--- a/echolocator/src/main.rs
+++ b/echolocator/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, process::Command};
+use std::env;
 
 use anyhow::{Context, Error, Result};
 use axum::{
@@ -9,7 +9,7 @@ use axum::{
 use futures_util::StreamExt;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
-use tokio::{fs::File, io::AsyncWriteExt};
+use tokio::{fs::File, io::AsyncWriteExt, process::Command};
 
 #[derive(Clone)]
 struct AppState {
@@ -112,7 +112,8 @@ async fn instruct(
             &prompt,
             "--log-disable",
         ])
-        .output()?;
+        .output()
+        .await?;
     let response = InstructResponse {
         completion: String::from_utf8(output.stdout)?
             // TODO: Prevent the output of the prompt rather than having to manually remove it from the completion

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1601,7 +1601,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/skimmer/src/service.rs
+++ b/skimmer/src/service.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env};
+use std::{collections::HashMap, env, time::Duration};
 
 use anyhow::{bail, Result};
 use chromiumoxide::browser::{Browser, BrowserConfig};
@@ -140,6 +140,7 @@ pub(crate) async fn post_instruct_summary(title: &str, text: &str) -> Result<Str
     );
     let response = client
         .post(instruct_endpoint)
+        .timeout(Duration::from_secs(600))
         .json(&payload)
         .send()
         .await?


### PR DESCRIPTION
## What
### `echolocator`
- Change to version `0.2.4`
- Use `tokio` command to call `llama`
  It seems like `tokio::process::Command` will be terminated as desired if the request is interrupted, while `std::process::Command` will continue running in this case.

### `skimmer`
- Change to version `0.2.2`
- Add timeout to instruct summary