### PR TITLE
Feature: skimmer fix vector repo init

### DIFF
--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.3.0
+          tags: metalwhaledev/newswaters-skimmer:0.3.1

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/skimmer/src/main.rs
+++ b/skimmer/src/main.rs
@@ -19,7 +19,6 @@ use crate::vector_repository::VectorRepository;
 async fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     let repo = Repository::new()?;
-    let vector_repo = VectorRepository::new().await?;
     let is_job = match env::var("SKIMMER_IS_JOB") {
         Ok(_) => true,
         Err(_) => false,
@@ -29,7 +28,10 @@ async fn main() -> Result<()> {
             "collect_items" => collect_items(Arc::new(Mutex::new(repo)), is_job).await?,
             "collect_item_urls" => collect_item_urls(Arc::new(Mutex::new(repo)), is_job).await?,
             "consume_top_stories" => consume_top_stories(repo, is_job).await?,
-            "consume_top_story_summaries" => consume_top_story_summaries(repo, vector_repo, is_job).await?,
+            "consume_top_story_summaries" => {
+                let vector_repo = VectorRepository::new().await?;
+                consume_top_story_summaries(repo, vector_repo, is_job).await?
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## What
### `skimmer`
- Change to version `0.3.1`
- Move vector repo init inside consumer block.