### PR TITLE
Feature: Change bert model

### DIFF
--- a/.github/workflows/echolocator.yml
+++ b/.github/workflows/echolocator.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:echolocator"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-echolocator:0.3.1
+          tags: metalwhaledev/newswaters-echolocator:0.3.2

--- a/.github/workflows/search-engine.yml
+++ b/.github/workflows/search-engine.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:search-engine"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-search-engine:0.2.0
+          tags: metalwhaledev/newswaters-search-engine:0.2.1

--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.3.3
+          tags: metalwhaledev/newswaters-skimmer:0.3.4

--- a/.github/workflows/whistler.yml
+++ b/.github/workflows/whistler.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:whistler"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-whistler:0.2.2
+          tags: metalwhaledev/newswaters-whistler:0.2.3

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -37,7 +37,6 @@ services:
       - SEARCH_ENGINE_VECTOR_HOST=search-engine-vector
       - SEARCH_ENGINE_VECTOR_PORT=6334
       - SEARCH_ENGINE_VECTOR_COLLECTION=app
-      - SEARCH_ENGINE_VECTOR_SIZE=768 # See: https://huggingface.co/jinaai/jina-embeddings-v2-base-en/blob/d411fe9/config.json#L18
       - SEARCH_ENGINE_TEXT_STORAGE_PATH=/usr/src/newswaters/search-engine/lib/tantivy/storage
     volumes:
       - ./:/usr/src/newswaters/

--- a/echolocator/Cargo.lock
+++ b/echolocator/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 [[package]]
 name = "candle-core"
 version = "0.3.0"
-source = "git+https://github.com/huggingface/candle.git?rev=0ec5ebc#0ec5ebcec429fe2bb85a6a7f780509bb1831b024"
+source = "git+https://github.com/huggingface/candle.git?rev=8a82d62#8a82d623e5ad919ba422bc796bd31b6fc3b91ab1"
 dependencies = [
  "byteorder",
  "gemm",
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.3.0"
-source = "git+https://github.com/huggingface/candle.git?rev=0ec5ebc#0ec5ebcec429fe2bb85a6a7f780509bb1831b024"
+source = "git+https://github.com/huggingface/candle.git?rev=8a82d62#8a82d623e5ad919ba422bc796bd31b6fc3b91ab1"
 dependencies = [
  "candle-core",
  "half",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.3.0"
-source = "git+https://github.com/huggingface/candle.git?rev=0ec5ebc#0ec5ebcec429fe2bb85a6a7f780509bb1831b024"
+source = "git+https://github.com/huggingface/candle.git?rev=8a82d62#8a82d623e5ad919ba422bc796bd31b6fc3b91ab1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "echolocator"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -521,6 +521,7 @@ dependencies = [
  "hf-hub",
  "reqwest",
  "serde",
+ "serde_json",
  "tokenizers",
  "tokio",
 ]

--- a/echolocator/Cargo.toml
+++ b/echolocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echolocator"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,13 +8,14 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 axum = "0.6.20"
-candle-core = { git = "https://github.com/huggingface/candle.git", rev = "0ec5ebc" }
-candle-nn = { git = "https://github.com/huggingface/candle.git", rev = "0ec5ebc" }
-candle-transformers = { git = "https://github.com/huggingface/candle.git", rev = "0ec5ebc" } # For "jina-bert"
+candle-core = { git = "https://github.com/huggingface/candle.git", rev = "8a82d62" }
+candle-nn = { git = "https://github.com/huggingface/candle.git", rev = "8a82d62" }
+candle-transformers = { git = "https://github.com/huggingface/candle.git", rev = "8a82d62" }
 futures-util = "0.3.28"
 hf-hub = "0.3.2"
 reqwest = { version = "0.11.22", features = ["stream"] }
 serde = { version = "1.0.189", features = ["derive"] }
+serde_json = "1.0.108"
 tokenizers = "0.14.1"
 tokio = { version = "1.33.0", features = [
     "macros",

--- a/echolocator/src/bert.rs
+++ b/echolocator/src/bert.rs
@@ -1,4 +1,6 @@
-// See: https://github.com/huggingface/candle/blob/0ec5ebc/candle-examples/examples/jina-bert/main.rs
+// See:
+// - https://github.com/huggingface/candle/blob/8a82d62/candle-examples/examples/bert/main.rs
+// - https://github.com/FlagOpen/FlagEmbedding/tree/b755dff/FlagEmbedding/llm_embedder#using-transformers
 
 #[cfg(feature = "mkl")]
 extern crate intel_mkl_src;
@@ -6,17 +8,15 @@ extern crate intel_mkl_src;
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src;
 
-use anyhow::{Error, Ok, Result};
-use candle_core::{DType, Device, Module, Tensor};
+use anyhow::{Error, Result};
+use candle_core::{Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::jina_bert::{BertModel, Config};
+use candle_transformers::models::bert::{BertModel, DTYPE};
 use hf_hub::{api::sync::Api, Repo, RepoType};
-use tokenizers::Tokenizer;
+use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
-const MODEL_NAME: &str = "jinaai/jina-embeddings-v2-base-en";
-const TOKENIZER_NAME: &str = "sentence-transformers/all-MiniLM-L6-v2";
+const MODEL_NAME: &str = "BAAI/llm-embedder";
 
-#[derive(Clone)]
 pub(crate) struct Bert {
     model: BertModel,
     tokenizer: Tokenizer,
@@ -24,33 +24,36 @@ pub(crate) struct Bert {
 
 impl Bert {
     pub(crate) fn new() -> Result<Self> {
-        let model_path = Api::new()?
-            .repo(Repo::new(MODEL_NAME.to_string(), RepoType::Model))
-            .get("model.safetensors")?;
-        let tokenizer = Tokenizer::from_file(
-            Api::new()?
-                .repo(Repo::new(TOKENIZER_NAME.to_string(), RepoType::Model))
-                .get("tokenizer.json")?,
-        )
-        .map_err(Error::msg)?;
-        let model = BertModel::new(
-            unsafe { VarBuilder::from_mmaped_safetensors(&[model_path], DType::F32, &Device::Cpu)? },
-            &Config::v2_base(),
+        let api = Api::new()?.repo(Repo::new(MODEL_NAME.to_string(), RepoType::Model));
+        let config = serde_json::from_str(&std::fs::read_to_string(api.get("config.json")?)?)?;
+        let model = BertModel::load(
+            VarBuilder::from_pth(&api.get("pytorch_model.bin")?, DTYPE, &Device::Cpu)?,
+            &config,
         )?;
+        let tokenizer = Tokenizer::from_file(api.get("tokenizer.json")?).map_err(Error::msg)?;
         return Ok(Self { model, tokenizer });
     }
 
     pub(crate) fn embed(&mut self, sentence: &str) -> Result<Vec<f32>> {
         let tokenizer = self
             .tokenizer
-            .with_padding(None)
-            .with_truncation(None)
+            .with_padding(Some(PaddingParams::default()))
+            .with_truncation(Some(TruncationParams::default()))
             .map_err(Error::msg)?;
         let tokens = tokenizer.encode(sentence, true).map_err(Error::msg)?.get_ids().to_vec();
         let token_ids = Tensor::new(&tokens[..], &self.model.device)?.unsqueeze(0)?;
-        let embedding = self.model.forward(&token_ids)?;
-        let (_sentences_num, tokens_num, _hidden_size) = embedding.dims3()?;
-        let embedding = (embedding.sum(1)? / (tokens_num as f64))?.squeeze(0)?;
-        Ok(embedding.to_vec1::<f32>()?)
+        let token_type_ids = token_ids.zeros_like()?;
+        let embedding = self
+            .model
+            .forward(&token_ids, &token_type_ids)?
+            // CLS pooling (See: https://huggingface.co/BAAI/llm-embedder/blob/01fe9c0/1_Pooling/config.json#L3)
+            .squeeze(0)?
+            .get(0)?;
+        let normalized_embedding = normalize_l2(&embedding)?;
+        Ok(normalized_embedding.to_vec1::<f32>()?)
     }
+}
+
+fn normalize_l2(v: &Tensor) -> Result<Tensor> {
+    Ok(v.broadcast_div(&v.sqr()?.sum_all()?.sqrt()?)?)
 }

--- a/search-engine/Cargo.lock
+++ b/search-engine/Cargo.lock
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "search-engine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/search-engine/Cargo.toml
+++ b/search-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "search-engine"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/search-engine/src/vector_repository.rs
+++ b/search-engine/src/vector_repository.rs
@@ -29,8 +29,8 @@ impl VectorRepository {
                     collection_name: collection_name.clone(),
                     vectors_config: Some(VectorsConfig {
                         config: Some(Config::Params(VectorParams {
-                            size: env::var("SEARCH_ENGINE_VECTOR_SIZE")?.parse()?,
-                            distance: Distance::Cosine.into(),
+                            size: 768, // See: https://huggingface.co/BAAI/llm-embedder/blob/01fe9c0/1_Pooling/config.json#L2
+                            distance: Distance::Dot.into(),
                             ..Default::default()
                         })),
                     }),

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1601,7 +1601,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/skimmer/src/service/inference.rs
+++ b/skimmer/src/service/inference.rs
@@ -51,7 +51,8 @@ struct EmbedResponse {
 
 pub(crate) async fn embed(sentence: &str) -> Result<Vec<f32>> {
     let mut payload = HashMap::new();
-    payload.insert("sentence", sentence);
+    // See: https://github.com/FlagOpen/FlagEmbedding/tree/b755dff/FlagEmbedding/llm_embedder#using-transformers
+    payload.insert("sentence", format!("Represent this document for retrieval: {sentence}"));
     let client = reqwest::Client::new();
     let endpoint = format!(
         "http://{}:{}/embed",

--- a/whistler/Cargo.lock
+++ b/whistler/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "whistler"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/whistler/Cargo.toml
+++ b/whistler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whistler"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/whistler/src/service/inference.rs
+++ b/whistler/src/service/inference.rs
@@ -11,7 +11,11 @@ struct EmbedResponse {
 // TODO: DRY this function to eliminate duplication with a similar one in "skimmer".
 pub(crate) async fn embed(sentence: &str) -> Result<Vec<f32>> {
     let mut payload = HashMap::new();
-    payload.insert("sentence", sentence);
+    // See: https://github.com/FlagOpen/FlagEmbedding/tree/b755dff/FlagEmbedding/llm_embedder#using-transformers
+    payload.insert(
+        "sentence",
+        format!("Represent this query for retrieving relevant documents: {sentence}"),
+    );
     let client = reqwest::Client::new();
     let endpoint = format!(
         "http://{}:{}/embed",


### PR DESCRIPTION
## What
### `search-engine`
- Change to version `0.2.1`

### `echolocator`
- Change to version `0.3.2`
- Use `llm-embedder` as embedding model

### `skimmer`
- Change to version `0.3.4`

### `whistler`
- Change to version `0.2.3`