### PR TITLE
Feature: skimmer consume additional item urls

### DIFF
--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.3.3
+          tags: metalwhaledev/newswaters-skimmer:0.3.4

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1601,7 +1601,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## What
### `skimmer`
- Change to version `0.3.4`
- Consume additional item urls along with top stories