### PR TITLE
Feature: change instruction

### DIFF
--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.6.0
+          tags: metalwhaledev/newswaters-skimmer:0.6.1

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1601,7 +1601,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/skimmer/src/service/inference.rs
+++ b/skimmer/src/service/inference.rs
@@ -17,7 +17,7 @@ pub(crate) async fn instruct_summary(title: &str, text: &str) -> Result<String> 
     let instruction = format!(
         "\
         Please generate related topics and provide a detailed summary that aligns with the title and omits any irrelevant text. \
-        Output only the title if the content is not related to it. \
+        Don't output the title. \
         Don't make up information if it's not provided.\n\n\
         Title:\n\
         {}\n\n\
@@ -54,7 +54,7 @@ pub(crate) async fn instruct_keyword(title: &str, text: &str) -> Result<String> 
 pub(crate) async fn instruct_summary_query(summary: &str) -> Result<String> {
     let instruction = format!(
         "\
-        Please generate up to {} queries aligning with the summary, omitting irrelevant text. \
+        Please generate {} queries aligning with the summary, omitting irrelevant text. \
         Output queries without additional explanation. \
         The queries can be affirmations or questions. \
         Each query should be fewer than {} words and have varying lengths. \


### PR DESCRIPTION
## What
### `skimmer`
- Change to version `0.6.1`
- Change summary and query instructions

## Release procedure
### Clean up data
Clear the `summary_query` column in `analyses` table by running:
```sql
UPDATE analyses SET summary_query = NULL WHERE summary_query IS NOT NULL;
```
We won't clear the `summary` column in `item_urls` table as we already have numerous generated summaries.

### Deployment notice
This release began deployment with [`wave/803a3be`](https://github.com/metalwhale/wave/blob/803a3be/manifests/newswaters/job.yaml#L155) commit, at `2023/11/21 11:21:00 JST`