### PR TITLE
Feature: skimmer analyze summaries generate triplet queries

### DIFF
--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.6.1
+          tags: metalwhaledev/newswaters-skimmer:0.6.2

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1601,7 +1601,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/skimmer/src/service/inference.rs
+++ b/skimmer/src/service/inference.rs
@@ -51,23 +51,45 @@ pub(crate) async fn instruct_keyword(title: &str, text: &str) -> Result<String> 
     return Ok(summary);
 }
 
-pub(crate) async fn instruct_summary_query(summary: &str) -> Result<String> {
+pub(crate) async fn instruct_anchor_query(content: &str) -> Result<String> {
     let instruction = format!(
         "\
-        Please generate {} queries aligning with the summary, omitting irrelevant text. \
-        Output queries without additional explanation. \
-        The queries must be in the form of instructions or questions. \
-        Each query should be fewer than {} words and have varying lengths.\n\n\
-        Summary:\n\
+        Please generate a sentence aligning with the provided content, omitting irrelevant text. \
+        Output the sentence without additional explanation. \
+        The sentence should be in the form of instructions and must not contain any proper nouns. \
+        Ensure it is fewer than {} words.\n\n\
+        Content:\n\
         {}\n\n\
-        Output in JSON array format (not object), with each element being one query.\n\n\
         ",
-        env::var("SKIMMER_INSTRUCT_SUMMARY_QUERY_MAX_QUERIES_NUM").unwrap_or("5".to_string()),
-        env::var("SKIMMER_INSTRUCT_SUMMARY_QUERY_MAX_WORDS_COUNT").unwrap_or("10".to_string()),
-        summary
+        env::var("SKIMMER_INSTRUCT_ANCHOR_QUERY_MAX_WORDS_COUNT").unwrap_or("20".to_string()),
+        content
     );
-    let summary = instruct(instruction).await?;
-    return Ok(summary);
+    let query = instruct(instruction).await?;
+    return Ok(query);
+}
+
+pub(crate) async fn instruct_entailment_query(premise: &str) -> Result<String> {
+    let instruction = format!(
+        "Refine the following sentence while keeping its meaning unchanged. \
+        Output the sentence without additional explanation.\n\n\
+        \"{}\"\n\
+        ",
+        premise
+    );
+    let hypothesis = instruct(instruction).await?;
+    return Ok(hypothesis);
+}
+
+pub(crate) async fn instruct_contradiction_query(premise: &str) -> Result<String> {
+    let instruction = format!(
+        "Make modifications to the following sentence, ensuring that its meaning becomes entirely contradictory. \
+        Output the sentence without additional explanation.\n\n\
+        \"{}\"\n\
+        ",
+        premise
+    );
+    let hypothesis = instruct(instruction).await?;
+    return Ok(hypothesis);
 }
 
 async fn instruct(instruction: String) -> Result<String> {


### PR DESCRIPTION
## What
### `skimmer`
- Change to version `0.6.2`
- Generate anchor, entailment and contradiction queries when analyzing summaries.

## Release procedure
Run:
```sql
UPDATE analyses SET summary_query = NULL WHERE summary_query IS NOT NULL;
```