### PR TITLE
Feature: skimmer analyze summaries generate subject query

### DIFF
--- a/.github/workflows/skimmer.yml
+++ b/.github/workflows/skimmer.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:skimmer"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-skimmer:0.6.2
+          tags: metalwhaledev/newswaters-skimmer:0.6.3

--- a/skimmer/Cargo.lock
+++ b/skimmer/Cargo.lock
@@ -1601,7 +1601,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "skimmer"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chromiumoxide",

--- a/skimmer/Cargo.toml
+++ b/skimmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skimmer"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/skimmer/src/command/analysis.rs
+++ b/skimmer/src/command/analysis.rs
@@ -124,6 +124,13 @@ pub(crate) async fn analyze_summaries(mut repo: Repository, is_job: bool) -> Res
                     continue;
                 }
             };
+            let subject_query = match inference::instruct_subject_query(&anchor_query).await {
+                Ok(query) => query,
+                Err(e) => {
+                    println!("[ERR] inference.instruct_query_entailment (id={id}): err={e}");
+                    continue;
+                }
+            };
             println!(
                 "[INFO] main.analyze_summaries (id={}): summary.len={}, \
                 anchor_query.len={}, entailment_query.len={}, contradiction_query.len={}, elapsed_time={:?}",
@@ -138,6 +145,7 @@ pub(crate) async fn analyze_summaries(mut repo: Repository, is_job: bool) -> Res
                 anchor: vec![anchor_query],
                 entailment: vec![entailment_query],
                 contradiction: vec![contradiction_query],
+                subject: subject_query.split("\n").map(str::to_string).collect(),
             })?;
             repo.update_analysis(id, summary_query)?;
         }
@@ -154,4 +162,5 @@ struct SummaryQuery {
     anchor: Vec<String>,
     entailment: Vec<String>,
     contradiction: Vec<String>,
+    subject: Vec<String>,
 }

--- a/skimmer/src/service/inference.rs
+++ b/skimmer/src/service/inference.rs
@@ -92,6 +92,25 @@ pub(crate) async fn instruct_contradiction_query(premise: &str) -> Result<String
     return Ok(hypothesis);
 }
 
+pub(crate) async fn instruct_subject_query(content: &str) -> Result<String> {
+    let instruction = format!(
+        "\
+        Please generate {} short queries aligning with the content, omitting irrelevant text. \
+        Output queries without additional explanation. \
+        Output each query on a separate line. \
+        The queries must be in the form of instructions or questions. \
+        Each query should be fewer than {} words and have varying lengths.\n\n\
+        Content:\n\
+        {}\n\n\
+        ",
+        env::var("SKIMMER_INSTRUCT_SUBJECT_QUERY_MAX_QUERIES_NUM").unwrap_or("5".to_string()),
+        env::var("SKIMMER_INSTRUCT_SUBJECT_QUERY_MAX_WORDS_COUNT").unwrap_or("5".to_string()),
+        content
+    );
+    let subject = instruct(instruction).await?;
+    return Ok(subject);
+}
+
 async fn instruct(instruction: String) -> Result<String> {
     let payload = InstructRequest { instruction };
     let client = reqwest::Client::new();


### PR DESCRIPTION
## What
### `skimmer`
- Change to version `0.6.3`
- Generate subject queries when analyzing summaries

## Release procedure
Run:
```sql
UPDATE analyses SET summary_query = NULL WHERE summary_query IS NOT NULL;
```