### PR TITLE
Feature: rename query to passage

### DIFF
--- a/newswaters-job/migrations/2023-11-20-113426_alter_analyses/down.sql
+++ b/newswaters-job/migrations/2023-11-20-113426_alter_analyses/down.sql
@@ -1,4 +1,0 @@
--- This file should undo anything in `up.sql`
-
-ALTER TABLE analyses
-DROP COLUMN summary_query;

--- a/newswaters-job/migrations/2023-11-20-113426_alter_analyses/up.sql
+++ b/newswaters-job/migrations/2023-11-20-113426_alter_analyses/up.sql
@@ -1,4 +1,0 @@
--- Your SQL goes here
-
-ALTER TABLE analyses
-ADD COLUMN summary_query text;

--- a/newswaters-job/migrations/2023-11-28-111810_alter_analyses/up.sql
+++ b/newswaters-job/migrations/2023-11-28-111810_alter_analyses/up.sql
@@ -1,4 +1,0 @@
--- Your SQL goes here
-
-ALTER TABLE analyses
-ADD COLUMN text_query text;

--- a/newswaters-job/migrations/2023-11-29-050702_alter_analyses/down.sql
+++ b/newswaters-job/migrations/2023-11-29-050702_alter_analyses/down.sql
@@ -1,4 +1,5 @@
 -- This file should undo anything in `up.sql`
 
 ALTER TABLE analyses
-DROP COLUMN text_query;
+DROP COLUMN summary_passage,
+DROP COLUMN text_passage;

--- a/newswaters-job/migrations/2023-11-29-050702_alter_analyses/up.sql
+++ b/newswaters-job/migrations/2023-11-29-050702_alter_analyses/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+
+ALTER TABLE analyses
+ADD COLUMN text_passage text,
+ADD COLUMN summary_passage text;

--- a/newswaters-job/src/command/analysis.rs
+++ b/newswaters-job/src/command/analysis.rs
@@ -91,7 +91,7 @@ pub(crate) async fn analyze_comment_texts(mut repo: Repository) -> Result<()> {
             }
         };
         // TODO: Generate a genuinely irrelevant passage
-        let irrelevance_passage = match inference::instruct_random_passage(&contradiction_passage).await {
+        let irrelevance_passage = match inference::instruct_random_passage(&anchor_passage).await {
             Ok(passage) => passage,
             Err(e) => {
                 println!("[ERR] inference.instruct_random_passage (id={id}): err={e}");
@@ -164,7 +164,7 @@ pub(crate) async fn analyze_summaries(mut repo: Repository) -> Result<()> {
             }
         };
         // TODO: Generate a genuinely irrelevant passage
-        let irrelevance_passage = match inference::instruct_random_passage(&contradiction_passage).await {
+        let irrelevance_passage = match inference::instruct_random_passage(&anchor_passage).await {
             Ok(passage) => passage,
             Err(e) => {
                 println!("[ERR] inference.instruct_random_passage (id={id}): err={e}");

--- a/newswaters-job/src/schema.rs
+++ b/newswaters-job/src/schema.rs
@@ -12,8 +12,8 @@ diesel::table! {
         keyword -> Nullable<Text>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
-        summary_query -> Nullable<Text>,
-        text_query -> Nullable<Text>,
+        text_passage -> Nullable<Text>,
+        summary_passage -> Nullable<Text>,
     }
 }
 

--- a/newswaters-job/src/service/inference.rs
+++ b/newswaters-job/src/service/inference.rs
@@ -52,7 +52,7 @@ pub(crate) async fn instruct_keyword(title: &str, text: &str) -> Result<String> 
     return Ok(summary);
 }
 
-pub(crate) async fn instruct_summary_anchor_query(summary: &str) -> Result<String> {
+pub(crate) async fn instruct_summary_anchor_passage(summary: &str) -> Result<String> {
     let instruction = format!(
         "\
         Please generate a sentence aligning with the provided content, omitting irrelevant text. \
@@ -61,14 +61,14 @@ pub(crate) async fn instruct_summary_anchor_query(summary: &str) -> Result<Strin
         Content:\n\
         {}\n\n\
         ",
-        env::var("JOB_INSTRUCT_SUMMARY_ANCHOR_QUERY_MAX_WORDS_COUNT").unwrap_or("20".to_string()),
+        env::var("JOB_INSTRUCT_SUMMARY_ANCHOR_PASSAGE_MAX_WORDS_COUNT").unwrap_or("20".to_string()),
         summary
     );
-    let query = instruct(instruction).await?;
-    return Ok(query);
+    let passage = instruct(instruction).await?;
+    return Ok(passage);
 }
 
-pub(crate) async fn instruct_comment_anchor_query(comment: &str) -> Result<String> {
+pub(crate) async fn instruct_comment_anchor_passage(comment: &str) -> Result<String> {
     let instruction = format!(
         "\
         Given the following content:\n\
@@ -79,13 +79,13 @@ pub(crate) async fn instruct_comment_anchor_query(comment: &str) -> Result<Strin
         Remove any irrelevant text.\n\
         ",
         comment,
-        env::var("JOB_INSTRUCT_COMMENT_ANCHOR_QUERY_MAX_WORDS_COUNT").unwrap_or("20".to_string())
+        env::var("JOB_INSTRUCT_COMMENT_ANCHOR_PASSAGE_MAX_WORDS_COUNT").unwrap_or("20".to_string())
     );
-    let query = instruct(instruction).await?;
-    return Ok(query);
+    let passage = instruct(instruction).await?;
+    return Ok(passage);
 }
 
-pub(crate) async fn instruct_entailment_query(premise: &str) -> Result<String> {
+pub(crate) async fn instruct_entailment_passage(premise: &str) -> Result<String> {
     let instruction = format!(
         "Refine the following sentence while keeping its meaning unchanged. \
         Output the sentence without additional explanation.\n\n\
@@ -97,7 +97,7 @@ pub(crate) async fn instruct_entailment_query(premise: &str) -> Result<String> {
     return Ok(hypothesis);
 }
 
-pub(crate) async fn instruct_contradiction_query(premise: &str) -> Result<String> {
+pub(crate) async fn instruct_contradiction_passage(premise: &str) -> Result<String> {
     let instruction = format!(
         "Make modifications to the following sentence, ensuring that its meaning becomes entirely contradictory. \
         Output the sentence without additional explanation.\n\n\
@@ -109,7 +109,7 @@ pub(crate) async fn instruct_contradiction_query(premise: &str) -> Result<String
     return Ok(hypothesis);
 }
 
-pub(crate) async fn instruct_random_query(original: &str) -> Result<String> {
+pub(crate) async fn instruct_random_passage(original: &str) -> Result<String> {
     let mut words = original
         .split(" ")
         .map(|n| n.to_string().to_lowercase())
@@ -118,7 +118,7 @@ pub(crate) async fn instruct_random_query(original: &str) -> Result<String> {
     words.shuffle(&mut rand::thread_rng());
     words.truncate(
         (sentence_len as f32
-            * env::var("JOB_INSTRUCT_RANDOM_QUERY_WORDS_RETENTION_RATE")
+            * env::var("JOB_INSTRUCT_RANDOM_PASSAGE_WORDS_RETENTION_RATE")
                 .unwrap_or("0.1".to_string())
                 .parse::<f32>()?) as usize
             + 1,
@@ -136,7 +136,7 @@ pub(crate) async fn instruct_random_query(original: &str) -> Result<String> {
     return Ok(hypothesis);
 }
 
-pub(crate) async fn instruct_subject_query(content: &str) -> Result<String> {
+pub(crate) async fn instruct_subject_passage(content: &str) -> Result<String> {
     let instruction = format!(
         "\
         Please generate {} different subjects aligning with the content. \
@@ -146,8 +146,8 @@ pub(crate) async fn instruct_subject_query(content: &str) -> Result<String> {
         Content:\n\
         {}\n\n\
         ",
-        env::var("JOB_INSTRUCT_SUBJECT_QUERY_MAX_SUBJECTS_NUM").unwrap_or("5".to_string()),
-        env::var("JOB_INSTRUCT_SUBJECT_QUERY_MAX_WORDS_COUNT").unwrap_or("5".to_string()),
+        env::var("JOB_INSTRUCT_SUBJECT_PASSAGE_MAX_SUBJECTS_NUM").unwrap_or("5".to_string()),
+        env::var("JOB_INSTRUCT_SUBJECT_PASSAGE_MAX_WORDS_COUNT").unwrap_or("5".to_string()),
         content
     );
     let subject = instruct(instruction).await?;

--- a/newswaters-job/src/service/inference.rs
+++ b/newswaters-job/src/service/inference.rs
@@ -61,7 +61,7 @@ pub(crate) async fn instruct_summary_anchor_passage(summary: &str) -> Result<Str
         Content:\n\
         {}\n\n\
         ",
-        env::var("JOB_INSTRUCT_SUMMARY_ANCHOR_PASSAGE_MAX_WORDS_COUNT").unwrap_or("20".to_string()),
+        env::var("JOB_INSTRUCT_SUMMARY_ANCHOR_PASSAGE_MAX_WORDS_COUNT").unwrap_or("40".to_string()),
         summary
     );
     let passage = instruct(instruction).await?;
@@ -79,7 +79,7 @@ pub(crate) async fn instruct_comment_anchor_passage(comment: &str) -> Result<Str
         Remove any irrelevant text.\n\
         ",
         comment,
-        env::var("JOB_INSTRUCT_COMMENT_ANCHOR_PASSAGE_MAX_WORDS_COUNT").unwrap_or("20".to_string())
+        env::var("JOB_INSTRUCT_COMMENT_ANCHOR_PASSAGE_MAX_WORDS_COUNT").unwrap_or("40".to_string())
     );
     let passage = instruct(instruction).await?;
     return Ok(passage);

--- a/newswaters-job/src/service/mod.rs
+++ b/newswaters-job/src/service/mod.rs
@@ -36,5 +36,5 @@ pub(crate) enum ItemUrl {
 pub(crate) struct Analysis {
     pub item_id: i32,
     pub keyword: Option<String>,
-    pub text_query: Option<String>,
+    pub text_passage: Option<String>,
 }


### PR DESCRIPTION
## What
### `job`
- Rename `query` to `passage`.
- Minor: change random passage's original to anchor; increase default max words count

## Release procedure
1. Revert the old migrations (as quick as possible):
    ```bash
    # Revert `2023-11-28-111810_alter_analyses`
    diesel migration revert
    
    # Revert `2023-11-20-113426_alter_analyses`
    diesel migration revert
    ```
2. Apply this PR
3. Run the new migration:
    ```
    diesel migration run
    ```
4. Delete rows that were created during the analysis of comment texts earlier:
    ```sql
    DELETE FROM analyses
    WHERE item_id IN (
        SELECT id
        FROM items
        LEFT JOIN analyses ON items.id = analyses.item_id
        WHERE "type" = 'comment' AND analyses.item_id IS NOT NULL
    )
    ```