### PR TITLE
Feature: inference change bert repo

### DIFF
--- a/.github/workflows/inference.yml
+++ b/.github/workflows/inference.yml
@@ -20,4 +20,4 @@ jobs:
           context: "{{defaultContext}}:newswaters-inference"
           file: Dockerfile.deployment
           push: true
-          tags: metalwhaledev/newswaters-inference:0.1.0
+          tags: metalwhaledev/newswaters-inference:0.1.1

--- a/newswaters-inference/Cargo.lock
+++ b/newswaters-inference/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "newswaters-inference"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/newswaters-inference/Cargo.toml
+++ b/newswaters-inference/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "newswaters-inference"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/newswaters-inference/src/bert.rs
+++ b/newswaters-inference/src/bert.rs
@@ -13,7 +13,7 @@ use candle_transformers::models::jina_bert::{BertModel, Config};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
 
-const MODEL_NAME: &str = "jinaai/jina-embeddings-v2-base-en";
+const MODEL_NAME: &str = "metalwhale/jina-embeddings-v2-base-en-ft";
 const TOKENIZER_NAME: &str = "sentence-transformers/all-MiniLM-L6-v2";
 
 #[derive(Clone)]


### PR DESCRIPTION
## What
### `inference`
- Upgrade to version `0.1.1`
- Change bert model to a self-hosted repo.

## Why
Preparing for a fine-tuning version